### PR TITLE
✨ feat: add get-api-docs and compound-learnings skills

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 REPO_SOURCE="${REPO_SOURCE:-zrr1999/skills}"
 SYSTEM_PACKAGES=(curl ca-certificates git git-lfs)
 XCMD_PACKAGES=(bun uv gh jq fzf duf bat rg fd sd lsd bottom dust procs delta difft hyperfine httpie)
+BUN_GLOBAL_PACKAGES=("@aisuite/chub")
 GH_EXTENSIONS=(
   "ShigureLab/gh-llm:gh-llm"
 )
@@ -151,6 +152,15 @@ ensure_gh_extensions() {
   done
 }
 
+install_chub() {
+  if has chub; then
+    log "chub already installed."
+    return
+  fi
+  log "Installing chub (Context Hub CLI)..."
+  bun install -g @aisuite/chub
+}
+
 install_system_packages() {
   if ! has apt-get; then
     log "apt-get not found; skipping apt-managed tools."
@@ -175,6 +185,8 @@ main() {
   install_xcmd_packages
   ensure_gh_extensions
   configure_tools
+
+  install_chub
 
   log "Installing skills from $REPO_SOURCE..."
   bunx skills add "$REPO_SOURCE" --all -g

--- a/skills/compound-learnings/SKILL.md
+++ b/skills/compound-learnings/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: compound-learnings
+description: 应在解决了一个非平凡问题后使用——例如踩坑修复、架构决策、性能调优、集成调试等场景。将解决方案沉淀为结构化的 learning 文件，让后续 session 能检索复用。也可在新 session 开始时用来检索已有 learnings。
+---
+
+## 目的
+
+每次工程工作应让后续工作更轻松。本 skill 提供一个**经验沉淀与检索机制**，将解决过的问题文档化为可检索的 learning 文件，避免重复踩坑。
+
+借鉴自 compound engineering 理念：80% 的价值在规划和复盘，20% 在执行。
+
+## 目录结构
+
+在项目根目录维护 `.learnings/` 文件夹：
+
+```
+.learnings/
+├── patterns/       # 可复用的模式和最佳实践
+├── gotchas/        # 踩坑记录和解决方案
+├── decisions/      # 架构和技术决策记录
+└── README.md       # 索引（自动维护）
+```
+
+## Learning 文件格式
+
+每个 learning 是一个 markdown 文件，带结构化 frontmatter：
+
+```markdown
+---
+title: "Webhook 验证必须使用 raw body"
+category: gotchas
+tags: [stripe, webhook, python]
+created: 2025-01-15
+context: "集成 Stripe webhook 时验证始终失败"
+---
+
+## 问题
+
+Stripe webhook 签名验证要求使用原始请求体（raw body），但 FastAPI 默认会解析 JSON。
+
+## 解决方案
+
+在验证前获取 raw body：
+
+\```python
+@app.post("/webhook")
+async def webhook(request: Request):
+    body = await request.body()  # raw bytes
+    sig = request.headers.get("stripe-signature")
+    event = stripe.Webhook.construct_event(body, sig, secret)
+\```
+
+## 关键点
+
+- 必须在任何 JSON 解析之前获取 raw body
+- `request.json()` 和 `request.body()` 不能同时调用（body 只能读一次）
+```
+
+## 沉淀流程（解决问题后）
+
+1. **识别沉淀时机** — 刚解决了一个耗时 >15 分钟的问题、做了一个非显而易见的技术决策、发现了一个文档未记录的坑
+2. **选择分类**：
+   - `patterns/` — 可复用的模式（如「用 X 做 Y 的标准方式」）
+   - `gotchas/` — 踩坑记录（如「X 在 Y 条件下会失败」）
+   - `decisions/` — 决策记录（如「选 X 而非 Y，因为...」）
+3. **撰写 learning** — 按上述文件格式写入 `.learnings/<category>/<slug>.md`
+4. **更新索引** — 在 `.learnings/README.md` 中追加条目
+
+## 检索流程（新 session 开始时）
+
+1. **自动扫描** — 检查当前项目是否有 `.learnings/` 目录
+2. **关键词匹配** — 根据当前任务的技术栈、库名、问题关键词搜索相关 learnings
+3. **呈现相关经验** — 将匹配的 learnings 摘要展示给 agent，作为上下文
+
+```bash
+# 搜索相关 learnings
+grep -rl "stripe" .learnings/
+grep -rl "webhook" .learnings/
+
+# 按 tag 搜索（在 frontmatter 中）
+grep -rl "tags:.*stripe" .learnings/
+```
+
+## 索引文件格式
+
+`.learnings/README.md` 作为索引：
+
+```markdown
+# Project Learnings
+
+## Patterns
+- [组件懒加载标准方式](patterns/lazy-loading.md) — React, performance
+
+## Gotchas
+- [Webhook 验证必须用 raw body](gotchas/stripe-webhook-raw-body.md) — stripe, webhook, python
+
+## Decisions
+- [选 FastAPI 而非 Flask](decisions/fastapi-over-flask.md) — python, web, framework
+```
+
+## 与其他 skill 的关系
+
+- 与 `get-api-docs` 互补：chub annotation 解决 API 文档补丁，本 skill 解决项目级经验沉淀
+- 与 `project-workflows` 互补：可作为 maintain-project 流程的收尾步骤
+- 与 `tech-preferences` 互补：decisions 分类中的选型决策可以反哺 tech-preferences 的偏好基线

--- a/skills/compound-learnings/evals/evals.json
+++ b/skills/compound-learnings/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "skill_name": "compound-learnings",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "刚花了半小时修好一个 Docker 多阶段构建的坑，uv 在 Alpine 上需要额外的编译依赖。帮我记录下来。",
+      "expected_output": "Agent 应将此经验沉淀到 .learnings/gotchas/ 目录，使用结构化 frontmatter 格式，并更新索引。",
+      "files": [],
+      "expectations": [
+        "创建 .learnings/gotchas/ 下的 markdown 文件",
+        "文件包含 frontmatter（title, category, tags, created, context）",
+        "内容包含问题描述和解决方案",
+        "更新 .learnings/README.md 索引"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "我要开始改这个项目的认证模块，先看看之前有没有相关的经验记录。",
+      "expected_output": "Agent 应检索 .learnings/ 目录中与认证相关的 learnings，展示相关经验摘要。",
+      "files": [],
+      "expectations": [
+        "检查 .learnings/ 目录是否存在",
+        "搜索与认证/auth 相关的 learnings",
+        "展示匹配的 learnings 摘要"
+      ]
+    }
+  ]
+}

--- a/skills/get-api-docs/SKILL.md
+++ b/skills/get-api-docs/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: get-api-docs
+description: 应在需要第三方库、SDK 或 API 文档时使用——例如「用 OpenAI API」「调 Stripe 接口」「查 Anthropic SDK」等场景。先用 chub 获取策划文档再作答，不要依赖训练数据中的 API 知识。
+---
+
+## 目的
+
+通过 `chub` CLI 获取社区维护的 API 文档，避免 agent 幻觉出错误的 API 用法。chub 提供 605+ 库的策划文档，支持多语言变体。
+
+## 工作流程
+
+### 查找文档
+
+```bash
+chub search "<库名>"            # 模糊搜索
+chub search "<库名>" --json     # 机器可读格式
+```
+
+### 获取文档
+
+```bash
+chub get <id> --lang py         # Python 变体
+chub get <id> --lang js         # JavaScript 变体
+chub get <id>                   # 单语言自动选择
+chub get <id> --full            # 含所有参考文件
+```
+
+### 使用文档
+
+阅读获取的内容，基于文档编写代码。**不要依赖记忆中的 API 签名**——以文档为准。
+
+### 标注经验
+
+完成任务后，如果发现文档未覆盖的坑（环境特定、版本差异、项目特定细节），保存标注：
+
+```bash
+chub annotate <id> "Webhook 验证需要 raw body，不要在验证前解析 JSON"
+```
+
+标注持久化在本地（`~/.chub/annotations/`），下次 `chub get` 同一文档时自动附带。
+
+## 快速参考
+
+| 目标 | 命令 |
+|------|------|
+| 列出所有文档 | `chub search` |
+| 搜索文档 | `chub search "stripe"` |
+| 获取 Python 文档 | `chub get stripe/api --lang py` |
+| 获取 JS 文档 | `chub get openai/chat --lang js` |
+| 保存到文件 | `chub get anthropic/sdk --lang py -o docs.md` |
+| 批量获取 | `chub get openai/chat stripe/api --lang py` |
+| 标注经验 | `chub annotate stripe/api "需要 raw body"` |
+| 查看所有标注 | `chub annotate --list` |
+
+## 不适用
+
+- 自己开发的项目文档——直接在项目内维护 `AGENTS.md` / `README.md` 更直接
+- 需要最新未发布版本的文档——chub 内容由社区维护，可能滞后
+- 纯内部 API——除非自己构建本地 chub content（参见 `chub build`）
+
+## 与其他 skill 的关系
+
+- 与 `tech-preferences` 正交：本 skill 解决「如何正确使用某库」，后者解决「该选哪个库」
+- 与 `modern-python` 互补：当 Python 项目需要某个库的文档时，先用本 skill 获取

--- a/skills/get-api-docs/evals/evals.json
+++ b/skills/get-api-docs/evals/evals.json
@@ -1,0 +1,27 @@
+{
+  "skill_name": "get-api-docs",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "帮我用 OpenAI 的 chat completion API 写一个 Python 调用，要用最新的 SDK。",
+      "expected_output": "Agent 应先用 chub search/get 获取 OpenAI 文档，再基于文档编写代码，而非依赖训练知识。",
+      "files": [],
+      "expectations": [
+        "使用 chub search 或 chub get 查找/获取文档",
+        "基于获取的文档内容编写代码",
+        "不直接从记忆中输出 API 调用"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "用 Stripe 的 Python SDK 实现一个支付接口，另外上次踩过 webhook 验证的坑，帮我查一下之前的标注。",
+      "expected_output": "Agent 应用 chub get 获取文档，且检查 chub annotate --list 或直接 get 时查看已有标注。",
+      "files": [],
+      "expectations": [
+        "使用 chub get stripe 相关文档",
+        "检查或提及 annotation 机制",
+        "基于文档和标注编写代码"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 变更内容

- 🔧 `install.sh` 新增 chub CLI (`@aisuite/chub`) 全局安装
- ✨ 新增 `get-api-docs` skill：通过 chub CLI 获取社区维护的 API 文档，避免 agent 幻觉
- ✨ 新增 `compound-learnings` skill：项目级经验沉淀与检索机制，将踩坑/决策/模式文档化为可搜索的 learning 文件

## 灵感

借鉴 compound engineering 理念与 context-hub 项目。