### PR TITLE
✨ feat(vet): merge quality-audit into vet with diff-level deslop track

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | 技能 | 主要结果 | 典型边界 |
 | --- | --- | --- |
 | `tech-preferences` | 技术栈/工具取舍与 Python 工具链落地 | 项目级模块、接口和状态边界仍由 `spark` 统筹 |
-| `quality-audit` | 有证据的维护质量或公开发布就绪审计 | 不替代普通 PR review、单点调试或纯安全渗透测试 |
+| `vet` | diff 级 AI slop 清理，或全仓质量审计与公开发布就绪预检 | 不替代正确性调试或纯安全渗透测试 |
 | `git-workstreams` | checkout/worktree、依赖 PR 拓扑与持续交付权限边界 | `gh stack` 直接读本机 help；worktree 显式 opt-in |
 
 ### 领域专用能力
@@ -43,9 +43,9 @@
 4. 混合请求可以加载多个 skill，但只指定一个结果所有者，避免两个 skill 同时规划整项工作。
 5. `gh stack` 请求统一由 `git-workstreams` 拥有结果并直接读取本机 help；外部 `gh-stack` skill 的静态命令、安装、配置、重试和权限规则不作为依赖或权威。
 
-原 `unix-software-design` 已简化并内置进 `spark`，原 `git-worktrees` 已更名为 `git-workstreams`，原 `roles` 已退役。
+原 `unix-software-design` 已简化并内置进 `spark`，原 `git-worktrees` 已更名为 `git-workstreams`，原 `roles` 已退役，原 `quality-audit` 已合入 `vet`（新增 diff 级轨道）。
 
-> 升级提示：安装流程不会自动删除用户级旧 skill。重新安装后若本机仍残留 `git-worktrees` 或 `roles`，请先用当前 skill manager 检查来源，再移除旧条目，避免过期 description 继续触发。
+> 升级提示：安装流程不会自动删除用户级旧 skill。重新安装后若本机仍残留 `git-worktrees`、`roles` 或 `quality-audit`，请先用当前 skill manager 检查来源，再移除旧条目，避免过期 description 继续触发。
 
 > `gh stack` CLI 与同名 skill 是两件事。保留 CLI 即可；若已安装外部 `gh-stack` skill，建议用当前 skill manager 检查并移除该 skill，避免它与 `git-workstreams` 重复触发。仓库不会自动删除用户级 skill。
 
@@ -92,7 +92,7 @@ pnpx skills add zrr1999/skills -g --agent cline --skill spark
 # 横切工程能力
 pnpx skills add zrr1999/skills -g --agent cline \
   --skill tech-preferences \
-  --skill quality-audit \
+  --skill vet \
   --skill git-workstreams
 
 # 领域专用能力，按需选择

--- a/skills/spark/SKILL.md
+++ b/skills/spark/SKILL.md
@@ -31,7 +31,7 @@ Spark 只拥有项目级结论和推进顺序；专项 skill 拥有自己的技�
 9. **交给更窄的 skill。** Spark 继续拥有整体推进，但不复制专项方法：
    - 技术栈、工具、仓库边界取舍或 Python 工具链：`tech-preferences`
    - 第三方 SDK/API 文档：`get-api-docs`
-   - 全仓维护质量或公开发布预检：`quality-audit`
+   - 代码质量审查：diff 级 AI slop 清理或全仓维护质量/公开发布预检：`vet`
    - worktree、branch/PR stack 或目标 PR 跟进：`git-workstreams`
    - 私有 SSH 设备事实源和信任：`ssh-fleet`
    - SVG/图标/Logo：`svg-design`

--- a/skills/vet/SKILL.md
+++ b/skills/vet/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: vet
+description: >
+  有证据的代码质量审查与清理，按范围分两种轨道：diff 级（写完代码/提交前清扫 AI 味：comment slop、防御性过度、过度抽象、幻觉 API、重复逻辑、泛泛命名、test theater，deletion-first 收敛到最小补丁）和仓库级（维护型技术债、架构健康、测试/依赖/配置审计，以及公开发布/开源/v1.0/package publish 前的 release readiness 预检）。触发：deslop、去 AI 味、清理或 review 刚才的改动、提交前自查、PR diff 质量、技术债/质量审计、开源前检查、Scorecard、REUSE。不用于正确性 bug 调试或纯安全渗透测试；Spark 仓库的 ownership/协议问题优先 spark-code-review。
+---
+
+# Vet
+
+把"代码质量"变成有证据、可决策、可修复的 finding。先定范围，再进对应轨道。
+
+## 定范围
+
+- **diff 轨道**（默认）：写完代码后、提交前、PR/diff review，或用户说 deslop / 清理 / review 刚才的改动。范围按优先级取：用户显式指定 > `git diff`（含 staged）> 本次会话改动。走下方 diff 流程。
+- **repo 轨道**：全仓技术债/架构/质量审计、公开发布或开源前的 release preflight。加载 `references/repo-audit.md` 执行。
+- 用户只要审查意见时（review-only）：不改代码，只输出 findings。
+- 不扩散：范围外发现记一句 backlog 即可；内部 CI/tag 检查不触发 release preflight。
+
+## 共享纪律
+
+- 每个 finding 带 `file:line` 或具体工具证据；拿不到证据就明说，不用猜测填充。
+- 先跑项目已有的 lint/typecheck/test 拿基线再动手；修复后重跑同一组，不借红绿模糊蒙混。
+- 修复一律 deletion-first：删代码、删抽象、删注释优先于新增；复用仓库已有工具函数；不引入新依赖；patch 保持最小。
+- 纯风格好恶（无具体 failure mode）不是 finding；仓库既有约定（命名风格、注释密度、抽象层级）优先于通用口味。
+- 幻觉指控先核实再定性：被指控的 API/flag/config key 对本地类型、`--help`、lockfile 或文档验证；建议的替代写法同样先验证存在且版本兼容——不以一个幻觉替换另一个幻觉。
+- 同一模式出现多次：合并成一条 finding 加代表性例子，不逐条刷屏。
+
+## Diff 轨道：deslop 流程
+
+1. **锁行为**：跑项目快速检查（typecheck + 相关测试）拿基线；已经失败的先记录。
+2. **读 diff 和上下文**：读完整改动块及足够周边代码，弄清已有 invariant 与可复用工具——"重复"和"防御过度"的判断必须锚在真实 invariant 上，不能凭感觉。
+3. **按 smell 表排查**，每条 finding 归类：`delete` / `consolidate` / `fix` / `consider`（判断题交给用户）。
+4. **deletion-first 修复**，顺序：死代码 → 重复 → 抽象 → 命名/注释 → 错误处理 → 测试。
+5. **重跑同一组检查**，报告删了什么、验证证据是什么。
+
+### Smell checklist
+
+| Smell | 检测信号 | 处理 |
+|---|---|---|
+| Comment slop | 注释复述下一行；docstring 复述签名；无信息的分节符；hedging（"this should work"） | 删。注释只解释 why；代码需要 what 注释时改写代码本身 |
+| Defensive overkill | 内部函数校验已由 invariant 保证的值；catch-log-reraise 零信息；给必需配置兜默认值；边界内层层重复校验 | 删。只在系统边界（用户输入/网络/反序列化/env）校验，内部信任 invariant；必需配置缺失要响亮失败 |
+| Over-abstraction | 单实现 interface；纯转发 wrapper；只调一次的 helper；一个操作套 Manager/Service/Factory；为假想需求预留的配置项 | inline 或删。测试 DI、确有多个实现、隔离外部依赖的除外 |
+| Hallucination | API/flag/config key/schema 字段"长得像真的"但未核实；从相邻生态抄来的参数；用 try/optional-chain 兜底掩盖不理解 | 按共享纪律核实；删除 invented surface |
+| Duplication | 不同文件里近乎相同的实现；sibling 目录下只换了名字的孪生模块 | 收敛到一个实现或参数化差异；新写 helper 前先查仓库是否已有 |
+| Generic naming | `data`/`result`/`temp`/`handler`/`manager`/`utils`/`helpers`/`common` 出现在非平凡作用域 | 换领域名；`utils.*` 垃圾抽屉按职责拆 |
+| Test theater | mock 掉所有依赖只断言调用次数；镜像实现控制流；snapshot 当唯一断言；只测 happy path | 改为断言行为/规格；mock 留在边界。判断标准：实现以同样方式写错时测试仍绿 = 摆设 |
+| Boilerplate | `result = f(); return result`；`return x ? true : false`；手写循环替代语言内建 | 用该语言的 idiomatic 短形式 |
+
+语言专属气味（Rust clone 滥用、Python 裸 except、TS any 等）见 `references/languages.md`，按 diff 实际涉及的语言加载，不涉及的不要套。
+
+### 审查独立性
+
+写完代码立刻自己宣布"质量很好"等于没审。
+
+- 同会话自查：当作独立一轮——从 diff 重新读起，不依赖写代码时的记忆和假设。
+- 有子代理可用：优先把 diff 交给独立子代理做 verifier 式审查，输入是 diff 和本清单；reviewer 只报告，取舍由编排层决定。
+- review-only 模式下不动手；修改模式下改完后必须重跑检查收尾，不允许"我改的就是对的"直接宣布通过。
+
+### Do not flag
+
+- 安全相关：auth、边界输入校验、TLS、rate limit——即使"看起来防御过度"。
+- 框架要求的结构与目录约定。
+- 没有具体 failure mode 的口味差异。
+
+## Output
+
+- diff 轨道：findings 按 `delete` / `consolidate` / `consider` 分组（每条带 `file:line`、smell 类别、一句话理由）+ 最小 patch + 验证证据。
+- repo 轨道：按 `references/repo-audit.md` 的输出约定；默认在对话中完成，不生成报告文件。
+
+## Stop
+
+- diff：范围内清单过完、修复验证通过即停，不为"还能更完美"追加第二轮。
+- repo：见 `references/repo-audit.md` 的停止规则。

--- a/skills/vet/evals/evals.json
+++ b/skills/vet/evals/evals.json
@@ -1,10 +1,10 @@
 {
-  "skill_name": "quality-audit",
+  "skill_name": "vet",
   "evals": [
     {
       "id": 1,
       "prompt": "这个仓库已经维护一段时间了，帮我做一次全仓库技术债和质量审计，最好能跑工具就跑工具，最后告诉我最该先修什么。",
-      "expected_output": "Agent 应使用 quality-audit 的 maintenance audit 模式，先做 orientation，再按工具类别收集证据，最后在对话中给出带 file:line、严重度、工作量、Top priorities、quick wins、误报排除和开放问题的结论；默认不生成报告文件。",
+      "expected_output": "Agent 应使用 vet 的 repo 轨道 maintenance audit 模式，先做 orientation，再按工具类别收集证据，最后在对话中给出带 file:line、严重度、工作量、Top priorities、quick wins、误报排除和开放问题的结论；默认不生成报告文件。",
       "files": [],
       "expectations": [
         "明确本次是 maintenance/technical-debt audit，而不是发布预检",
@@ -12,13 +12,13 @@
         "工具结果按类别组织，而不是简单堆命令输出",
         "每个具体 finding 有 file:line 或明确工具证据",
         "输出包含 Top priorities、quick wins、things that look bad but are actually fine 或等价误报排除",
-        "默认不生成或更新 QUALITY_AUDIT.md 等报告文件"
+        "默认不生成或更新报告文件"
       ]
     },
     {
       "id": 2,
       "prompt": "我准备把这个 repo 公开发布，Scorecard 分数低，REUSE 也有报错。你帮我把开源前问题都处理一下。",
-      "expected_output": "Agent 应使用 quality-audit 的 public-release preflight 模式，把 Scorecard、REUSE、license、公开时机等作为发布风险和用户决策处理，不应机械修分或直接公开 repo。",
+      "expected_output": "Agent 应使用 vet 的 repo 轨道 public-release preflight 模式，把 Scorecard、REUSE、license、公开时机等作为发布风险和用户决策处理，不应机械修分或直接公开 repo。",
       "files": [],
       "expectations": [
         "明确这是公开发布/开源前 release preflight",
@@ -30,7 +30,7 @@
     {
       "id": 3,
       "prompt": "我要今天发 v1.0 并把 GitHub repo 公开。跑下安全检查就行，分数低的你直接修。",
-      "expected_output": "Agent 应使用 quality-audit 的 release/mixed 流程，但不能盲目自动修所有低分项；应说明工具分数是信号，并把高风险或行为性修复交给用户确认。",
+      "expected_output": "Agent 应使用 vet 的 release/mixed 流程，但不能盲目自动修所有低分项；应说明工具分数是信号，并把高风险或行为性修复交给用户确认。",
       "files": [],
       "expectations": [
         "说明 Scorecard 或工具分数不是自动 gate",
@@ -42,7 +42,7 @@
     {
       "id": 4,
       "prompt": "这个 TypeScript monorepo 感觉重复代码和复杂度都上来了，帮我用 jscpd、lizard、madge、knip 之类的工具分门别类扫一下，再综合判断。",
-      "expected_output": "Agent 应使用 quality-audit 的 maintenance/mixed 工具流程，将 jscpd 归入 duplication，lizard 归入 complexity hotspots，madge 归入 architecture graph，knip 归入 dependency hygiene，并强调工具缺失时记录原因、不全局安装。",
+      "expected_output": "Agent 应使用 vet 的 repo 轨道 maintenance/mixed 工具流程，将 jscpd 归入 duplication，lizard 归入 complexity hotspots，madge 归入 architecture graph，knip 归入 dependency hygiene，并强调工具缺失时记录原因、不全局安装。",
       "files": [],
       "expectations": [
         "按审计类别分类 jscpd、lizard、madge、knip",
@@ -54,7 +54,7 @@
     {
       "id": 5,
       "prompt": "我想从更抽象一点的数学结构角度看这个代码库，比如群论、环论、范畴论那种，看看架构有没有隐藏债务。",
-      "expected_output": "Agent 应使用 quality-audit 的 Structural / algebraic lens，但必须把数学观察翻译成具体维护风险，并要求 file:line 证据，不能输出纯术语化或无证据的玄学评价。",
+      "expected_output": "Agent 应使用 vet 的 Structural / algebraic lens，但必须把数学观察翻译成具体维护风险，并要求 file:line 证据，不能输出纯术语化或无证据的玄学评价。",
       "files": [],
       "expectations": [
         "包含 symmetry/algebraic/composition 或等价结构 lens",
@@ -66,7 +66,7 @@
     {
       "id": 6,
       "prompt": "I'm creating a new open source repo today. Before I make it public, do a quick preflight and tell me what I need to fix.",
-      "expected_output": "Agent should use quality-audit's public-release preflight mode, run or propose Scorecard/security/repo-hygiene checks, and separate blockers from non-blocking follow-ups.",
+      "expected_output": "Agent should use vet's repo-track public-release preflight mode, run or propose Scorecard/security/repo-hygiene checks, and separate blockers from non-blocking follow-ups.",
       "files": [],
       "expectations": [
         "Output uses English",
@@ -78,7 +78,7 @@
     {
       "id": 7,
       "prompt": "准备开源这个服务，但我也担心它内部架构有点乱。你帮我统一做一轮质量检查：哪些公开前必须修，哪些只是后续技术债优化。",
-      "expected_output": "Agent 应使用 quality-audit 的 mixed mode，先区分公开前 Blocker/User Decision，再列维护型技术债 Top priorities，避免把长期 polish 当作发布 blocker。",
+      "expected_output": "Agent 应使用 vet 的 repo 轨道 mixed mode，先区分公开前 Blocker/User Decision，再列维护型技术债 Top priorities，避免把长期 polish 当作发布 blocker。",
       "files": [],
       "expectations": [
         "明确采用 mixed mode",
@@ -90,24 +90,48 @@
     {
       "id": 8,
       "prompt": "帮我 review 这个 PR 的 diff，重点看有没有引入技术债。",
-      "expected_output": "Agent 不应启动全仓库 quality-audit；应走 PR/diff review，并可借用质量/技术债维度做审查 lens，但范围保持在 diff 和相关上下文。",
+      "expected_output": "Agent 不应启动全仓库审计；应走 vet 的 diff 轨道（或普通 PR review），可借用质量/技术债维度做审查 lens，但范围保持在 diff 和相关上下文。",
       "files": [],
       "expectations": [
         "明确这是 PR/diff review，不是全仓库审计",
         "审查范围保持在 diff 和必要相关上下文",
         "可以使用架构、重复、测试、类型等质量维度作为 review lens",
-        "不要求生成 QUALITY_AUDIT.md"
+        "不生成全仓审计报告文件"
       ]
     },
     {
       "id": 9,
       "prompt": "我们这个内部服务今天要发一个 CI tag，帮我检查 release 流程有没有明显问题，不涉及开源或公开仓库。",
-      "expected_output": "Agent 不应使用 quality-audit 的 public-release preflight；应按普通项目维护或 CI/release 调试流程处理。只有涉及公开发布、开源、Scorecard、license/security/public readiness 时才触发 release preflight。",
+      "expected_output": "Agent 不应使用 vet 的 public-release preflight；应按普通项目维护或 CI/release 调试流程处理。只有涉及公开发布、开源、Scorecard、license/security/public readiness 时才触发 release preflight。",
       "files": [],
       "expectations": [
         "未启动公开发布预检或 Scorecard/license 决策流程",
         "明确范围是内部 CI/release 检查",
         "如需项目推进，应转向普通调试/维护流程"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "刚用 AI 给这个项目加了个缓存层，代码能跑但看着有点过度设计，注释也啰嗦。帮我清理一下这次的改动。",
+      "expected_output": "Agent 应使用 vet 的 diff 轨道 deslop 流程：范围限定在本次 diff，先跑项目已有检查拿基线，按 smell 清单排查（过度抽象、comment slop、防御性过度、幻觉 API 等），deletion-first 给出最小补丁，改完重跑同一组检查。",
+      "files": [],
+      "expectations": [
+        "范围限定在本次 diff/改动文件，不扩散到全仓",
+        "修改前先运行项目已有的 typecheck/test 拿基线",
+        "finding 带 file:line 与一句话理由，并按 delete/consolidate/consider 或等价分类",
+        "修复以删除和收敛为主，不新增抽象层或依赖",
+        "修改后重跑同一组检查验证"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "帮我把整个 src/ 目录按 anti-slop 标准清理一遍，所有 AI 味都去掉。",
+      "expected_output": "全目录清理超出 diff 轨道的默认范围；Agent 应与用户确认范围，或转入 repo 轨道的 maintenance audit 先取证再排优先级，不直接对全目录做删除式改写。",
+      "files": [],
+      "expectations": [
+        "不直接在全目录范围执行删除式改写",
+        "明确区分 diff 轨道默认范围与全仓审计",
+        "转向 repo maintenance audit 流程或要求用户确认范围后再动手"
       ]
     }
   ]

--- a/skills/vet/references/languages.md
+++ b/skills/vet/references/languages.md
@@ -1,0 +1,39 @@
+# Language-specific slop
+
+按 diff 实际涉及的语言加载本节。通用清单见 `SKILL.md`；这里只补各语言特有、且通用清单盖不住的信号。
+
+## Rust
+
+- **Clone abuse**：为逃 borrow checker 到处 `.clone()`——最典型的 AI Rust 信号。先重新想所有权/借用设计，clone 是最后手段。
+- **Error type proliferation**：每个模块自定义 error enum。应用层用 `anyhow`，库用 `thiserror`。
+- **Trait bound 堆砌**：`T: Display + Debug + Clone + Send + Sync` 实际只用了 `Display`。
+- **Verbose**：两臂 `match` 该用 `if let`；函数末尾显式 `return`；手动 match Option/Result 而不用 combinator。
+- **Stale**：`extern crate`、`#[macro_use]`、`try!()`、`lazy_static`（1.80+ 用 `std::sync::LazyLock`）。
+
+## Python
+
+- **Class-for-everything**：无状态类应是函数或模块级代码。
+- **Exception**：裸 `except:`（吞 KeyboardInterrupt/SystemExit）；`except Exception as e: logger.error(e); raise` 零信息；对签名已声明类型的参数做 None check。
+- **Stale**：`os.path` 而非 `pathlib`；`.format()` 而非 f-string；`typing.Optional[X]` 而非 `X | None`（3.10+）。
+- **Type hints**：用 `Any` 绕过类型错误；显然可推断处的冗余标注。
+- **Dep creep**：为单个 GET 引入 `requests`。
+- **Tells**：`dict.get(..., {})` 链式兜底洗 missing invariant；mock 重度测试无行为断言。
+
+## TypeScript / JavaScript
+
+- **Type abuse**：可推断处冗余标注；`any` 代替 `unknown`；enum 代替 const object/union。
+- **Stale**：ESM 里 `require()`；`var`；`React.FC`；`.then()` 链代替 async/await。
+- **Barrel files**：小目录里 `index.ts` 纯 re-export，徒增 import 间接层。
+- **Dep creep**：`node-fetch`（fetch 已全局）、`uuid`（有 `crypto.randomUUID()`）、两个库干同一件事。
+- **Tells**：确定性本地代码包 try/catch；`new Promise(async ...)`；必需 env/config 给兜底默认值。
+
+## Shell
+
+- 缺 `set -euo pipefail`；变量不加引号。
+- `cat file | grep`；反引号代替 `$()`；解析 `ls` 输出。
+- 每行 `if cmd; then ... fi` 代替 `set -e`；手动查 `$?`。
+- `2>/dev/null || true` 掩盖不确定；幻觉 flag——一律对 `--help` 验证。
+
+## 其他语言
+
+Go 及未列出的语言：只套用 `SKILL.md` 通用清单，并在报告里注明语言专项检查已跳过。不要把某一语言的 idiom 套到另一语言上。

--- a/skills/vet/references/repo-audit.md
+++ b/skills/vet/references/repo-audit.md
@@ -1,14 +1,10 @@
----
-name: quality-audit
-description: >-
-  对单个仓库、子树或相关仓库做有证据的质量审计与优化规划：维护型技术债、架构健康、可维护性、测试、依赖/配置、CI/仓库卫生，或公开发布/开源/v1.0/package publish 前的 release readiness、Scorecard、安全、许可证和 public surface 预检。先判断 maintenance、public-release、mixed 或 portfolio，再读取现场、运行适合的检查、给出带 file:line 或工具证据的风险分级和优先级。默认不生成报告。不要用于普通 PR diff review、单点 bug 调试或纯安全渗透测试。
----
+# Repo audit（vet 的仓库级轨道）
 
-# Quality Audit
+仅在 repo 范围时加载：全仓技术债/架构/质量审计，或公开发布/开源/v1.0/package publish 前的 release readiness 预检。diff 级审查回 `../SKILL.md` 的 diff 轨道。
 
 ## Goal
 
-把“这个仓库哪里有风险、先修什么、哪些只是长期债务”变成可决策的证据。结论必须区分真实风险、用户决策、低风险修复和 backlog，不把工具分数直接当 gate，也不把长期 polish 伪装成发布 blocker。
+把"这个仓库哪里有风险、先修什么、哪些只是长期债务"变成可决策的证据。结论必须区分真实风险、用户决策、低风险修复和 backlog，不把工具分数直接当 gate，也不把长期 polish 伪装成发布 blocker。
 
 ## Mode and boundary
 
@@ -19,7 +15,7 @@ description: >-
 - **mixed**：同时存在公开发布和内部质量问题时，先 release readiness，再 maintenance priorities。
 - **portfolio**：用户明确要求多个相关仓库；先确定纳入/排除集合，每个仓库都必须有本地可读路径才能给 `file:line` 证据。
 
-普通 PR/diff review 只看 diff 和必要上下文；内部 CI/tag 检查只走普通维护或 release 调试，不启动 public-release preflight。不要替用户公开仓库、选择许可证、重写历史、轮换密钥、删除数据或做高风险升级。
+内部 CI/tag 检查只走普通维护或 release 调试，不启动 public-release preflight。不要替用户公开仓库、选择许可证、重写历史、轮换密钥、删除数据或做高风险升级。
 
 ## Inspect first
 
@@ -47,7 +43,7 @@ description: >-
 | Static and tests | `tsc`、`ruff`、`ty`、`clippy`、`go vet`、仓库测试与 coverage；关注高 churn 无测试、skip/flaky |
 | Documentation drift | README 命令与真实 install/build/run/release 路径是否一致 |
 
-工具输出只是线索。一个根因合并为一个 finding，工具结果和代码阅读作为同一条 evidence；每个 finding 要有 `file:line`、具体工具结果或明确说明“未能取得证据”。
+工具输出只是线索。一个根因合并为一个 finding，工具结果和代码阅读作为同一条 evidence；每个 finding 要有 `file:line`、具体工具结果或明确说明"未能取得证据"。
 
 ## Semantic lenses
 


### PR DESCRIPTION
## 动机

AI 生成代码"能跑但一眼 AI 味"的清理（diff 级 deslop）与原 `quality-audit`（全仓审计/发布预检）本质是同一件事在不同范围上的投射：有证据的质量审查。拆成两个 skill 会让触发边界模糊（PR diff review 到底归谁），合并后统一入口、按范围分轨道。

## 改动

- **新增 `skills/vet/`**：
  - `SKILL.md`：范围路由（diff 默认 / repo）+ 共享纪律（证据、基线检查、deletion-first、幻觉先核实再定性）+ diff 轨道完整流程（锁行为 → 读 diff → smell 清单 → deletion-first 修复 → 重跑验证）+ 审查独立性约定（优先交给独立子代理做 verifier 式审查，reviewer 只报告）
  - `references/repo-audit.md`：原 quality-audit 全仓审计内容（maintenance / public-release / mixed / portfolio），按需加载，git 识别为 rename（81% 相似度）
  - `references/languages.md`：语言专属气味（Rust clone 滥用、Python 裸 except、TS barrel files、Shell 安全等）
- **删除 `skills/quality-audit/`**，evals 迁移并新增 2 条 diff 轨道用例（deslop 主路径、全目录清理的范围纪律）
- **README**：分层表、按层安装命令同步；升级提示补充旧 `quality-audit` 残留（沿用 git-worktrees 更名先例）
- **`spark/SKILL.md`**：路由表指向 `vet`

## 验证

- `bash scripts/check-evals.sh` 通过（`skill_name` 与目录一致，11 条 evals）
- `prek run --all-files` 全部钩子通过（含 commit-msg 钩子）

参考来源：iuliandita/skills 的 anti-slop（smell 目录）、oh-my-claudecode 的 ai-slop-cleaner（deletion-first 工作流与 writer/reviewer 分离）、trisouro/slop-guard（机械检查思路，留待各仓库 lint 层落地）。